### PR TITLE
Alex selection fix

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.59.0",
+  "version": "0.59.1-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-history",
   "description": "An operation-based history implementation for Slate editors.",
-  "version": "0.59.0",
+  "version": "0.59.1-alpha.0",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -18,8 +18,8 @@
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {
-    "slate": "^0.59.0",
-    "slate-hyperscript": "^0.59.0"
+    "slate": "^0.59.1-alpha.0",
+    "slate-hyperscript": "^0.59.1-alpha.0"
   },
   "peerDependencies": {
     "slate": ">=0.55.0"

--- a/packages/slate-hyperscript/package.json
+++ b/packages/slate-hyperscript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-hyperscript",
   "description": "A hyperscript helper for creating Slate documents.",
-  "version": "0.59.0",
+  "version": "0.59.1-alpha.0",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -17,7 +17,7 @@
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {
-    "slate": "^0.59.0"
+    "slate": "^0.59.1-alpha.0"
   },
   "peerDependencies": {
     "slate": ">=0.55.0"

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.59.0",
+  "version": "0.59.1-alpha.0",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",
@@ -23,8 +23,8 @@
     "scroll-into-view-if-needed": "^2.2.20"
   },
   "devDependencies": {
-    "slate": "^0.59.0",
-    "slate-hyperscript": "^0.59.0"
+    "slate": "^0.59.1-alpha.0",
+    "slate-hyperscript": "^0.59.1-alpha.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -180,7 +180,13 @@ export const Editable = (props: EditableProps) => {
     const el = ReactEditor.toDOMNode(editor, editor)
     state.isUpdatingSelection = true
 
-    const newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
+    let newDomRange: DOMRange | null = null
+
+    try {
+      newDomRange = selection && ReactEditor.toDOMRange(editor, selection)
+    } catch (err) {
+      // Invalid selection
+    }
 
     if (newDomRange) {
       if (Range.isBackward(selection!)) {

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate",
   "description": "A completely customizable framework for building rich text editors.",
-  "version": "0.59.0",
+  "version": "0.59.1-alpha.0",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",


### PR DESCRIPTION
Sometimes the editor's children can change and the selection becomes invalid. 

Rather than throwing an error, just reset the selection.